### PR TITLE
Improve error context

### DIFF
--- a/modules/@apostrophecms/area/index.js
+++ b/modules/@apostrophecms/area/index.js
@@ -39,7 +39,7 @@ module.exports = {
           const field = self.apos.schema.getFieldById(areaFieldId);
 
           if (!field) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req, areaFieldId });
           }
 
           const widgets = self.getWidgets(field.options);
@@ -49,7 +49,7 @@ module.exports = {
           const manager = self.getWidgetManager(type);
           if (!manager) {
             self.warnMissingWidgetType(type);
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req, type });
           }
           widget = await sanitize(widget);
           widget._edit = true;
@@ -381,14 +381,14 @@ module.exports = {
         async function find() {
           const doc = await self.apos.doc.find(req, { _id: docId }).permission('edit').toObject();
           if (!doc) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req, _id: docId });
           }
           return doc;
         }
         async function update(doc) {
           const components = dotPath.split(/\./);
           if (_.includes(self.forbiddenAreas, components[0])) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
           // If it's not a top level property, it's
           // always okay - unless it already exists
@@ -396,7 +396,7 @@ module.exports = {
           if (components.length > 1) {
             const existing = _.get(doc, dotPath);
             if (existing && existing.metaType !== 'area') {
-              throw self.apos.error('forbidden');
+              throw self.apos.error('forbidden', { req });
             }
           }
           const existingArea = _.get(doc, dotPath);

--- a/modules/@apostrophecms/area/lib/custom-tags/area.js
+++ b/modules/@apostrophecms/area/lib/custom-tags/area.js
@@ -73,7 +73,7 @@ module.exports = function(self) {
         if (docId) {
           let mainDoc = await self.apos.doc.db.findOne({ _id: docId });
           if (!mainDoc) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { _id: docId });
           }
           let docDotPath;
           try {
@@ -81,7 +81,7 @@ module.exports = function(self) {
           } catch (e) {
             // Race condition: someone removed the area's parent object.
             // Unlikely thanks to advisory locking
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { _id: docId });
           }
           const areaDotPath = docDotPath ? `${docDotPath}.${name}` : name;
           await self.apos.doc.db.updateOne({

--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -164,7 +164,7 @@ module.exports = {
               const file = Object.values(req.files || {})[0];
 
               if (!file) {
-                throw self.apos.error('invalid');
+                throw self.apos.error('invalid', { req });
               }
 
               const attachment = await self.insert(req, file);
@@ -201,13 +201,13 @@ module.exports = {
             const { crop } = req.body;
 
             if (!_id || !crop || typeof crop !== 'object' || Array.isArray(crop)) {
-              throw self.apos.error('invalid');
+              throw self.apos.error('invalid', { req, _id });
             }
 
             const sanitizedCrop = self.sanitizeCrop(crop);
 
             if (!sanitizedCrop) {
-              throw self.apos.error('invalid');
+              throw self.apos.error('invalid', { req, _id });
             }
 
             await self.crop(req, _id, sanitizedCrop);
@@ -419,7 +419,7 @@ module.exports = {
         };
         if (!(options.permissions === false)) {
           if (!self.apos.permission.can(req, 'upload-attachment')) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
         }
         info.length = await self.apos.util.fileLength(file.path);
@@ -466,7 +466,7 @@ module.exports = {
       async update(req, file, attachment) {
         const existing = await self.db.findOne({ _id: attachment._id });
         if (!existing) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req, _id: attachment._id });
         }
 
         const projection = {
@@ -533,7 +533,7 @@ module.exports = {
         const info = await self.db.findOne({ _id });
 
         if (!info) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req, _id });
         }
 
         if (!self.croppable[info.extension]) {

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -774,7 +774,7 @@ module.exports = {
         if (options.copyingId) {
           copyOf = await self.findOneForCopying(req, { _id: options.copyingId });
           if (!copyOf) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           input = {
             ...copyOf,
@@ -834,7 +834,7 @@ module.exports = {
       // and `at` properties.
       async submit(req, draft) {
         if (!self.apos.permission.can(req, 'edit', draft)) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', { req });
         }
         const submitted = {
           by: req.user && req.user.title,
@@ -855,10 +855,10 @@ module.exports = {
       async dismissSubmission(req, draft) {
         if (!self.apos.permission.can(req, 'publish', draft)) {
           if (!self.apos.permission.can(req, 'edit', draft)) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
           if (!(draft.submitted && (draft.submitted.byId === req.user._id))) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
         }
         // Don't use "return" here, that could leak mongodb details
@@ -1127,7 +1127,7 @@ module.exports = {
                     .toObject();
                   if (!originalTarget) {
                     // Almost impossible (race conditions like someone removing it while we're in the modal)
-                    throw self.apos.error('notfound');
+                    throw self.apos.error('notfound', { req });
                   }
                   const criteria = {
                     path: self.apos.page.getParentPath(originalTarget)
@@ -1260,7 +1260,7 @@ module.exports = {
 
       async revertPublishedToPrevious(req, published) {
         if (!self.apos.permission.can(req, 'publish', published)) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', { req });
         }
         const previousId = published._id.replace(':published', ':previous');
         const previous = await self.apos.doc.db.findOne({
@@ -1268,7 +1268,7 @@ module.exports = {
         });
         if (!previous) {
           // Feature has already been used
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', { req });
         }
         const $set = await self.getRevertDeduplicationSet(req, previous);
         Object.assign(previous, $set);
@@ -1460,7 +1460,7 @@ module.exports = {
 
       async share(req, doc) {
         if (doc._edit !== true) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
 
         if (!doc._url) {
@@ -1486,7 +1486,7 @@ module.exports = {
 
       async unshare(req, doc) {
         if (doc._edit !== true) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
 
         if (!doc._url) {

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -52,7 +52,7 @@ module.exports = {
         _id = self.apos.i18n.inferIdLocaleAndMode(req, _id);
         const doc = await self.find(req, { _id }).permission('edit').toObject();
         if (!doc) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req, _id });
         }
         return doc;
       }
@@ -63,7 +63,7 @@ module.exports = {
       post: {
         async slugTaken(req) {
           if (!req.user) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           const slug = self.apos.launder.string(req.body.slug);
           const _id = self.apos.launder.id(req.body._id);
@@ -94,7 +94,7 @@ module.exports = {
         // might not be accepted as a query string.
         async editable(req) {
           if (!req.user) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           const ids = self.apos.launder.ids(req.body.ids);
           if (!ids.length) {
@@ -191,7 +191,7 @@ module.exports = {
         testPermissions(req, doc, options) {
           if (!(options.permissions === false)) {
             if (!self.apos.permission.can(req, 'delete', doc)) {
-              throw self.apos.error('forbidden');
+              throw self.apos.error('forbidden', { req });
             }
           }
         }
@@ -200,7 +200,7 @@ module.exports = {
         testPermissions(req, info) {
           if (info.options.permissions !== false) {
             if (!self.apos.permission.can(req, info.options.autopublishing ? 'edit' : 'publish', info.draft)) {
-              throw self.apos.error('forbidden');
+              throw self.apos.error('forbidden', { req });
             }
           }
         }
@@ -349,7 +349,7 @@ module.exports = {
           const [ from, to ] = pair;
           const existing = await self.apos.doc.db.findOne({ _id: from });
           if (!existing) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { _id: from });
           }
           const replacement = klona(existing);
           await self.apos.doc.db.removeOne({ _id: from });
@@ -870,7 +870,7 @@ module.exports = {
       testInsertPermissions(req, doc, options) {
         if (options.permissions !== false) {
           if (!self.apos.permission.can(req, 'create', doc)) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
         }
       },
@@ -913,7 +913,7 @@ module.exports = {
 
       async deleteBody(req, doc, options) {
         if ((options.permissions !== false) && (!self.apos.permission.can(req, 'delete', doc))) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', { req });
         }
         return self.db.removeOne({
           _id: doc._id
@@ -1333,17 +1333,17 @@ module.exports = {
             }
           });
           if (!info) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { _id });
           }
           if (!info.advisoryLock) {
             // Nobody else has a lock but you couldn't get one —
             // must be permissions
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
           if (!info.advisoryLock) {
             // Nobody else has a lock but you couldn't get one —
             // must be permissions
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
           if (info.advisoryLock.username === req.user.username) {
             throw self.apos.error('locked', {

--- a/modules/@apostrophecms/error/index.js
+++ b/modules/@apostrophecms/error/index.js
@@ -26,9 +26,21 @@ module.exports = {
           data = message;
           message = null;
         }
+        const context = {};
+        if (data.req) {
+          const req = data.req;
+          context.method = req.method;
+          context.url = req.originalUrl || req.url;
+          if (!data._id && req.params && req.params._id) {
+            context._id = req.params._id;
+          } else if (!data._id && req.body && req.body._id) {
+            context._id = req.body._id;
+          }
+          delete data.req;
+        }
         const error = new Error(message || name);
         error.name = name;
-        error.data = data;
+        error.data = { ...data, ...context };
 
         // Establish a difference between errors built here and those elsewhere.
         error.aposError = true;

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -400,7 +400,7 @@ module.exports = {
             }
           }
           if (!sanitizedLocale) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           const result = {};
           if (doc && doc._url) {
@@ -437,7 +437,7 @@ module.exports = {
         // might not be accepted as a query string.
         async existInLocale(req) {
           if (!req.user) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           const ids = self.apos.launder.ids(req.body.ids);
           const locale = self.apos.launder.string(req.body.locale);
@@ -445,7 +445,7 @@ module.exports = {
           const originalMode = (ids[0] && ids[0].split(':')[2]) || req.mode;
           const mode = self.apos.launder.string(req.body.mode, originalMode);
           if (!self.isValidLocale(locale)) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req, locale });
           }
           const found = await self.apos.doc.db.find({
             aposLocale: `${locale}:${mode}`,
@@ -614,7 +614,7 @@ module.exports = {
           mode = req.mode;
         }
         if ((req.mode === 'draft') && (!self.apos.permission.can(req, 'view-draft'))) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', { req });
         }
         if (_id.charAt(0) === '_') {
           // A shortcut such as _home or _archive,

--- a/modules/@apostrophecms/image/index.js
+++ b/modules/@apostrophecms/image/index.js
@@ -144,7 +144,7 @@ module.exports = {
     post: {
       async autocrop(req) {
         if (!self.apos.permission.can(req, 'upload-attachment')) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', { req });
         }
         const widgetOptions = sanitizeOptions(req.body.widgetOptions);
         if (!widgetOptions.aspectRatio) {

--- a/modules/@apostrophecms/job/index.js
+++ b/modules/@apostrophecms/job/index.js
@@ -52,14 +52,14 @@ module.exports = {
     return {
       async getOne(req, _id) {
         if (!self.apos.permission.can(req, 'view-draft')) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
 
         const jobId = self.apos.launder.id(_id);
         const job = await self.db.findOne({ _id: jobId });
 
         if (!job) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req, _id: jobId });
         }
 
         job.percentage = !job.total ? 0 : (job.processed / job.total * 100).toFixed(2);

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -134,7 +134,7 @@ module.exports = {
         },
         async logout(req) {
           if (!req.user) {
-            throw self.apos.error('forbidden', req.t('apostrophe:logOutNotLoggedIn'));
+            throw self.apos.error('forbidden', req.t('apostrophe:logOutNotLoggedIn'), { req });
           }
           if (req.token) {
             await self.bearerTokens.removeOne({
@@ -175,7 +175,7 @@ module.exports = {
 
           const requirement = self.requirements[name];
           if (!requirement) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!requirement.props) {
             return {};
@@ -192,13 +192,13 @@ module.exports = {
           );
 
           if (!user) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
 
           const requirement = self.requirements[name];
 
           if (!requirement) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
 
           if (!requirement.verify) {
@@ -227,7 +227,7 @@ module.exports = {
             });
 
             if (!token) {
-              throw self.apos.error('notfound');
+              throw self.apos.error('notfound', { req });
             }
 
             await self.bearerTokens.updateOne(token, {
@@ -603,7 +603,7 @@ module.exports = {
           })
           .toObject();
         if (!user) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req: adminReq });
         }
         if (resetToken !== false) {
           await self.apos.user.verifySecret(
@@ -647,11 +647,11 @@ module.exports = {
         });
 
         if (!token) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
 
         if (token.requirementsToVerify.length) {
-          throw self.apos.error('forbidden', 'All requirements must be verified');
+          throw self.apos.error('forbidden', 'All requirements must be verified', { req });
         }
 
         const user = await self.deserializeUser(token.userId);
@@ -659,7 +659,7 @@ module.exports = {
           await self.bearerTokens.removeOne({
             _id: token.userId
           });
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
 
         if (session) {
@@ -703,14 +703,14 @@ module.exports = {
           }
         });
         if (!token) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
         const user = await self.deserializeUser(token.userId);
         if (!user) {
           await self.bearerTokens.removeOne({
             _id: token._id
           });
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
         return {
           token,

--- a/modules/@apostrophecms/notification/index.js
+++ b/modules/@apostrophecms/notification/index.js
@@ -51,13 +51,13 @@ module.exports = {
       async route(req) {
         let modifiedOnOrSince;
         if (!(req.user && req.user._id)) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', { req });
         }
         const start = Date.now();
         try {
           modifiedOnOrSince = req.query.modifiedOnOrSince && new Date(req.query.modifiedOnOrSince);
         } catch (e) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', { req });
         }
         const seenIds = req.query.seenIds && self.apos.launder.ids(req.query.seenIds);
         return await attempt();
@@ -192,7 +192,7 @@ module.exports = {
               }
             });
           } catch (error) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req, _id: req.params._id });
           } finally {
             await self.apos.lock.unlock(lockId);
           }
@@ -265,10 +265,10 @@ module.exports = {
           req = { user: { _id: req } };
         }
         if (!req.user) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', { req });
         }
         if (!message) {
-          throw self.apos.error('required');
+          throw self.apos.error('required', { req });
         }
 
         req.body = req.body || {};
@@ -326,7 +326,7 @@ module.exports = {
       //   notification actually dismisses.
       async dismiss (req, noteId, delay) {
         if (!req.user) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', { req });
         }
 
         await pause(delay);
@@ -354,7 +354,7 @@ module.exports = {
           );
         } catch (error) {
           // Most likely the ID did not belong to an actual notification.
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', { req });
         }
 
         async function pause (delay) {

--- a/modules/@apostrophecms/page-type/index.js
+++ b/modules/@apostrophecms/page-type/index.js
@@ -153,7 +153,7 @@ module.exports = {
       beforeMove: {
         checkPermissions(req, doc) {
           if (doc.lastPublishedAt && !self.apos.permission.can(req, 'publish', doc)) {
-            throw self.apos.error('forbidden', 'Contributors may only move unpublished pages.');
+            throw self.apos.error('forbidden', 'Contributors may only move unpublished pages.', { req });
           }
         }
       },
@@ -403,7 +403,7 @@ module.exports = {
         // Check publish permission up front because we won't check it
         // in insert
         if (!self.apos.permission.can(req, 'publish', doc)) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', { req });
         }
         const _req = req.clone({
           mode: 'published'

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -141,11 +141,11 @@ module.exports = {
 
           if (autocomplete.length) {
             if (!self.apos.permission.can(req, 'view', '@apostrophecms/any-page-type')) {
-              throw self.apos.error('forbidden');
+              throw self.apos.error('forbidden', { req });
             }
 
             if (type.length && !self.apos.permission.can(req, 'view', type)) {
-              throw self.apos.error('forbidden');
+              throw self.apos.error('forbidden', { req });
             }
 
             const query = self.getRestQuery(req).permission(false).limit(10).relationships(false)
@@ -164,7 +164,7 @@ module.exports = {
           if (type.length) {
             const manager = self.apos.doc.getManager(type);
             if (!manager) {
-              throw self.apos.error('invalid');
+              throw self.apos.error('invalid', { req });
             }
 
             const query = self.getRestQuery(req);
@@ -192,7 +192,7 @@ module.exports = {
 
           if (all) {
             if (!self.apos.permission.can(req, 'view', '@apostrophecms/any-page-type')) {
-              throw self.apos.error('forbidden');
+              throw self.apos.error('forbidden', { req });
             }
             const page = await self.getRestQuery(req).permission(false).and({ level: 0 }).children({
               depth: 1000,
@@ -210,7 +210,7 @@ module.exports = {
             }
 
             if (!page) {
-              throw self.apos.error('notfound');
+              throw self.apos.error('notfound', { req });
             }
 
             if (flat) {
@@ -233,7 +233,7 @@ module.exports = {
             }
 
             if (!result) {
-              throw self.apos.error('notfound');
+              throw self.apos.error('notfound', { req });
             }
 
             // Attach `_url` and `_urls` properties to the home page
@@ -275,7 +275,7 @@ module.exports = {
           }
 
           if (!result) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (self.apos.launder.boolean(req.query['render-areas']) === true) {
             await self.apos.area.renderDocsAreas(req, [ result ]);
@@ -311,7 +311,7 @@ module.exports = {
         const input = _.omit(req.body, '_targetId', '_position', '_copyingId');
         if (typeof (input) !== 'object') {
           // cheeky
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', { req });
         }
 
         if (req.body._newInstance) {
@@ -332,12 +332,12 @@ module.exports = {
             .toObject();
 
           if (!targetPage) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           const manager = self.apos.doc.getManager(self.apos.launder.string(input.type));
           if (!manager) {
             // sneaky
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           let page;
           if ((position === 'firstChild') || (position === 'lastChild')) {
@@ -345,7 +345,7 @@ module.exports = {
           } else {
             const parentPage = targetPage._ancestors[targetPage._ancestors.length - 1];
             if (!parentPage) {
-              throw self.apos.error('notfound');
+              throw self.apos.error('notfound', { req });
             }
             page = self.newChild(parentPage);
           }
@@ -391,15 +391,15 @@ module.exports = {
         return self.withLock(req, async () => {
           const page = await self.findForEditing(req, { _id }).toObject();
           if (!page) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!page._edit) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
           const input = req.body;
           const manager = self.apos.doc.getManager(self.apos.launder.string(input.type) || page.type);
           if (!manager) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           let tabId = null;
           let lock = false;
@@ -439,7 +439,7 @@ module.exports = {
         });
 
         if (!page) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
         return self.delete(req, page);
       },
@@ -466,11 +466,11 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!draft) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!draft.aposLocale) {
             // Not subject to draft/publish workflow
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           return self.publish(req, draft);
         },
@@ -482,16 +482,16 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!draft) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!draft.aposLocale) {
             // Not subject to draft/publish workflow
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           const toLocale = self.apos.i18n.sanitizeLocaleName(req.body.toLocale);
           const update = self.apos.launder.boolean(req.body.update);
           if ((!toLocale) || (toLocale === req.locale)) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           return self.localize(req, draft, toLocale, {
             update
@@ -506,7 +506,7 @@ module.exports = {
             aposDocId
           });
           if (!published) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           return self.withLock(
             req,
@@ -521,7 +521,7 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!draft) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           const manager = self.apos.doc.getManager(draft.type);
           return manager.submit(req, draft);
@@ -534,7 +534,7 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!draft) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           const manager = self.apos.doc.getManager(draft.type);
           return manager.dismissSubmission(req, draft);
@@ -547,11 +547,11 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!draft) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!draft.aposLocale) {
             // Not subject to draft/publish workflow
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           return self.revertDraftToPublished(req, draft);
         },
@@ -563,11 +563,11 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!published) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!published.aposLocale) {
             // Not subject to draft/publish workflow
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           return self.revertPublishedToPrevious(req, published);
         },
@@ -576,7 +576,7 @@ module.exports = {
           const share = self.apos.launder.boolean(req.body.share);
 
           if (!_id) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
 
           const draft = await self.findOneForEditing(req, {
@@ -584,7 +584,7 @@ module.exports = {
           });
 
           if (!draft || draft.aposMode !== 'draft') {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
 
           const sharedDoc = share
@@ -790,10 +790,10 @@ database.`);
           const page = await self.findOneForEditing(req, { _id });
           let result;
           if (!page) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!page._edit) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
           const patches = Array.isArray(input._patches) ? input._patches : [ input ];
           // Conventional for loop so we can handle the last one specially
@@ -845,7 +845,7 @@ database.`);
       async applyPatch(req, page, input) {
         const manager = self.apos.doc.getManager(self.apos.launder.string(input.type) || page.type);
         if (!manager) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', { req });
         }
         self.apos.schema.implementPatchOperators(input, page);
         const parentPage = page._ancestors.length && page._ancestors[page._ancestors.length - 1];
@@ -930,7 +930,7 @@ database.`);
           let peers;
           const target = await self.getTarget(req, targetId, position);
           if (!target) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           let parent;
           if ((position === 'before') || (position === 'after')) {
@@ -949,11 +949,11 @@ database.`);
             peers = target._children;
           }
           if (!parent) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (options.permissions !== false) {
             if (!parent._create) {
-              throw self.apos.error('forbidden');
+              throw self.apos.error('forbidden', { req });
             }
           }
           let pushed = [];
@@ -978,7 +978,7 @@ database.`);
             page.rank = target.rank;
             const index = peers.findIndex(peer => peer._id === target._id);
             if (index === -1) {
-              throw self.apos.error('notfound');
+              throw self.apos.error('notfound', { req });
             }
             pushed = peers.slice(index).map(peer => peer._id);
           } else if (position === 'after') {
@@ -1025,7 +1025,7 @@ database.`);
           // (`page-type` module).
           if (page.lastPublishedAt && !parent.lastPublishedAt) {
             await self.unpublish(req, page);
-            throw self.apos.error('forbidden', 'Publish the parent page first.');
+            throw self.apos.error('forbidden', 'Publish the parent page first.', { req });
           }
           return page;
         });
@@ -1167,11 +1167,11 @@ database.`);
           await manager.emit('beforeMove', req, moved, target, position);
           determineRankAndNewParent();
           if (!moved._edit) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
           if (!(parent && oldParent)) {
             // Move outside tree
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
           if (
             (oldParent._id !== parent._id) &&
@@ -1179,10 +1179,10 @@ database.`);
             (!parent._create) &&
             (oldParent.type === '@apostrophecms/archive-page' && !parent._edit)
           ) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
           if (moved.lastPublishedAt && !parent.lastPublishedAt) {
-            throw self.apos.error('forbidden', 'Publish the parent page first.');
+            throw self.apos.error('forbidden', 'Publish the parent page first.', { req });
           }
           await nudgeNewPeers();
           await moveSelf();
@@ -1338,10 +1338,10 @@ database.`);
             permission: false
           }).toObject();
         if (!target) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
         if (target.type === '@apostrophecms/archive-page' && target.level === 1 && position === 'after') {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', { req });
         }
         return target;
       },
@@ -1459,7 +1459,7 @@ database.`);
         }
         const page = await findPage();
         if (!page) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
         const parent = page._ancestors[0];
         if (!parent) {
@@ -2427,7 +2427,7 @@ database.`);
       publicApiCheck(req) {
         if (!self.options.publicApiProjection) {
           if (!self.canAccessApi(req)) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
         }
       },

--- a/modules/@apostrophecms/permission/index.js
+++ b/modules/@apostrophecms/permission/index.js
@@ -338,7 +338,7 @@ module.exports = {
       },
       grid(req, role) {
         if (!self.can(req, 'edit', '@apostrophecms/user')) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', { req });
         }
         const permissionSets = [];
         const effectiveRole = self.apos.launder.select(role, [ 'guest', 'contributor', 'editor', 'admin' ]);

--- a/modules/@apostrophecms/piece-type/index.js
+++ b/modules/@apostrophecms/piece-type/index.js
@@ -289,7 +289,7 @@ module.exports = {
           }
 
           if (!doc) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (self.apos.launder.boolean(req.query['render-areas']) === true) {
             await self.apos.area.renderDocsAreas(req, [ doc ]);
@@ -350,17 +350,17 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!draft) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!draft.aposLocale) {
             // Not subject to draft/publish workflow
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           return self.publish(req, draft);
         },
         async publish (req) {
           if (!Array.isArray(req.body._ids)) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
 
           req.body._ids = req.body._ids.map(_id => {
@@ -374,7 +374,7 @@ module.exports = {
               const piece = await self.findOneForEditing(req, { _id: id });
 
               if (!piece) {
-                throw self.apos.error('notfound');
+                throw self.apos.error('notfound', { req });
               }
 
               await self.publish(req, piece);
@@ -385,7 +385,7 @@ module.exports = {
         },
         async archive (req) {
           if (!Array.isArray(req.body._ids)) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
 
           req.body._ids = req.body._ids.map(_id => {
@@ -399,7 +399,7 @@ module.exports = {
               const piece = await self.findOneForEditing(req, { _id: id });
 
               if (!piece) {
-                throw self.apos.error('notfound');
+                throw self.apos.error('notfound', { req });
               }
 
               piece.archived = true;
@@ -411,7 +411,7 @@ module.exports = {
         },
         async restore (req) {
           if (!Array.isArray(req.body._ids)) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
 
           req.body._ids = req.body._ids.map(_id => {
@@ -425,7 +425,7 @@ module.exports = {
               const piece = await self.findOneForEditing(req, { _id: id });
 
               if (!piece) {
-                throw self.apos.error('notfound');
+                throw self.apos.error('notfound', { req });
               }
 
               piece.archived = false;
@@ -443,15 +443,15 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!draft) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!draft.aposLocale) {
             // Not subject to draft/publish workflow
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           const toLocale = self.apos.i18n.sanitizeLocaleName(req.body.toLocale);
           if ((!toLocale) || (toLocale === req.locale)) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           const update = self.apos.launder.boolean(req.body.update);
           return self.localize(req, draft, toLocale, {
@@ -467,7 +467,7 @@ module.exports = {
             aposDocId
           });
           if (!published) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           return self.unpublish(req, published);
         },
@@ -479,7 +479,7 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!draft) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           return self.submit(req, draft);
         },
@@ -491,7 +491,7 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!draft) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           return self.dismissSubmission(req, draft);
         },
@@ -503,11 +503,11 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!draft) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!draft.aposLocale) {
             // Not subject to draft/publish workflow
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           return self.revertDraftToPublished(req, draft);
         },
@@ -519,11 +519,11 @@ module.exports = {
             aposDocId: _id.split(':')[0]
           });
           if (!published) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!published.aposLocale) {
             // Not subject to draft/publish workflow
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           return self.revertPublishedToPrevious(req, published);
         },
@@ -532,7 +532,7 @@ module.exports = {
           const share = self.apos.launder.boolean(req.body.share);
 
           if (!_id) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
 
           const draft = await self.findOneForEditing(req, {
@@ -540,7 +540,7 @@ module.exports = {
           });
 
           if (!draft || draft.aposMode !== 'draft') {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
 
           const sharedDoc = share
@@ -673,7 +673,7 @@ module.exports = {
         // Check publish permission up front because we won't check it
         // in insert
         if (!self.apos.permission.can(req, 'publish', doc)) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', { req });
         }
         return self.insert(
           req.clone({ mode: 'published' }),
@@ -689,7 +689,7 @@ module.exports = {
       requireOneForEditing(req, criteria) {
         const piece = self.findForEditing(req, criteria).toObject();
         if (!piece) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
         return piece;
       },
@@ -783,7 +783,7 @@ module.exports = {
       //   async function one(req, id) {
       //     const piece = self.findForEditing(req, { _id: id }).toObject();
       //     if (!piece) {
-      //       throw self.apos.error('notfound');
+      //       throw self.apos.error('notfound', { req });
       //     }
       //     await change(req, piece, data);
       //   }
@@ -855,10 +855,10 @@ module.exports = {
         return self.apos.lock.withLock(`@apostrophecms/${_id}`, async () => {
           const piece = await self.findOneForEditing(req, { _id });
           if (!piece) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           if (!piece._edit) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', { req });
           }
           let tabId = null;
           let lock = false;
@@ -928,7 +928,7 @@ module.exports = {
           const piece = await self.findOneForEditing(req, { _id });
           let result;
           if (!piece) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           const patches = Array.isArray(input._patches)
             ? input._patches
@@ -1035,7 +1035,7 @@ module.exports = {
       publicApiCheck(req) {
         if (!self.options.publicApiProjection) {
           if (!self.canAccessApi(req)) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
         }
       },

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -1783,7 +1783,7 @@ module.exports = {
             !self.fieldTypes[field.type].dynamicChoices ||
             !(field.choices && typeof field.choices === 'string')
           ) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', { req });
           }
           try {
             choices = await self.evaluateMethod(req, field.choices, field.name, field.moduleName, docId, true);
@@ -1807,7 +1807,7 @@ module.exports = {
           const allowedKeys = getFieldExternalConditionKeys(field);
           // We must tolerate arguments at this stage as we only warn about them later
           if (!allowedKeys.includes(conditionKey.replace(/\(.*\)/, '()'))) {
-            throw self.apos.error('forbidden', `${conditionKey} is not registered as an external condition.`);
+            throw self.apos.error('forbidden', `${conditionKey} is not registered as an external condition.`, { req });
           }
           try {
             const result = await self.evaluateMethod(req, conditionKey, field.name, field.moduleName, docId);

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -102,14 +102,14 @@ module.exports = (self) => {
       // This is new and until now if JS client side failed, then it would
       // allow the save with empty values -Lars
       if (field.required && (_.isUndefined(data[field.name]) || !data[field.name].toString().length)) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', { req, field: field.name });
       }
 
       if (field.pattern) {
         const regex = new RegExp(field.pattern);
 
         if (!regex.test(destination[field.name])) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', { req, field: field.name });
         }
       }
     },
@@ -259,7 +259,7 @@ module.exports = (self) => {
       destination[field.name] = self.apos.launder.string(data[field.name], field.def);
 
       if (field.required && (_.isUndefined(destination[field.name]) || !destination[field.name].toString().length)) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', { req, field: field.name });
       }
 
       const test = tinycolor(destination[field.name]);
@@ -440,10 +440,10 @@ module.exports = (self) => {
     async convert(req, field, data, destination) {
       destination[field.name] = self.apos.launder.integer(data[field.name], field.def, field.min, field.max);
       if (field.required && ((data[field.name] == null) || !data[field.name].toString().length)) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', { req, field: field.name });
       }
       if (data[field.name] && isNaN(parseFloat(data[field.name]))) {
-        throw self.apos.error('invalid');
+        throw self.apos.error('invalid', { req, field: field.name });
       }
       // This makes it possible to have a field that is not required, but min / max defined.
       // This allows the form to be saved and sets the value to null if no value was given by
@@ -494,10 +494,10 @@ module.exports = (self) => {
     async convert(req, field, data, destination) {
       destination[field.name] = self.apos.launder.float(data[field.name], field.def, field.min, field.max);
       if (field.required && (_.isUndefined(data[field.name]) || !data[field.name].toString().length)) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', { req, field: field.name });
       }
       if (data[field.name] && isNaN(parseFloat(data[field.name]))) {
-        throw self.apos.error('invalid');
+        throw self.apos.error('invalid', { req, field: field.name });
       }
       if (!data[field.name] && data[field.name] !== 0) {
         destination[field.name] = null;
@@ -546,13 +546,13 @@ module.exports = (self) => {
       destination[field.name] = self.apos.launder.string(data[field.name]);
       if (!data[field.name]) {
         if (field.required) {
-          throw self.apos.error('required');
+          throw self.apos.error('required', { req, field: field.name });
         }
       } else {
         // regex source: https://emailregex.com/
         const matches = data[field.name].match(/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);
         if (!matches) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', { req, field: field.name });
         }
       }
       destination[field.name] = data[field.name];
@@ -566,14 +566,14 @@ module.exports = (self) => {
       destination[field.name] = self.apos.launder.url(data[field.name], field.def, true);
 
       if (field.required && (data[field.name] == null || !data[field.name].toString().length)) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', { req, field: field.name });
       }
 
       if (field.pattern) {
         const regex = new RegExp(field.pattern);
 
         if (!regex.test(destination[field.name])) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', { req, field: field.name });
         }
       }
     },
@@ -735,10 +735,10 @@ module.exports = (self) => {
     async convert(req, field, data, destination) {
       destination[field.name] = self.apos.launder.float(data[field.name], field.def, field.min, field.max);
       if (field.required && (_.isUndefined(data[field.name]) || !data[field.name].toString().length)) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', { req, field: field.name });
       }
       if (data[field.name] && isNaN(parseFloat(data[field.name]))) {
-        throw self.apos.error('invalid');
+        throw self.apos.error('invalid', { req, field: field.name });
       }
       // Allow for ranges to go unset
       // `min` here does not imply requirement, it is the minimum value the range UI will represent
@@ -806,7 +806,7 @@ module.exports = (self) => {
       }
       destination[field.name] = results;
       if (field.required && !results.length) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', { req, field: field.name });
       }
       if ((field.min !== undefined) && (results.length < field.min)) {
         throw self.apos.error('min');

--- a/modules/@apostrophecms/settings/index.js
+++ b/modules/@apostrophecms/settings/index.js
@@ -556,7 +556,7 @@ module.exports = {
     return {
       async getAll(req) {
         if (!self.hasSchema() || !req.user) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
         const user = await self.apos.user
           .find(req, { _id: req.user._id })
@@ -564,7 +564,7 @@ module.exports = {
           .toObject();
 
         if (!user) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
 
         const values = {
@@ -583,14 +583,14 @@ module.exports = {
       patch: {
         ':subform': async (req) => {
           if (!self.hasSchema() || !req.user) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
           let subform = self.getSubform(
             self.apos.launder.string(req.params.subform)
           );
 
           if (!subform || !subform.schema.length) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
 
           await self.handleProtectedSubform(req, subform, req.body);
@@ -605,7 +605,7 @@ module.exports = {
             .toObject();
 
           if (!user) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', { req });
           }
 
           await self.apos.schema.convert(req, subform.schema, req.body, user);

--- a/modules/@apostrophecms/translation/index.js
+++ b/modules/@apostrophecms/translation/index.js
@@ -96,7 +96,7 @@ module.exports = {
       // contain all supported languages for the source/target.
       async languages(req) {
         if (!self.isEnabled() || !self.canAccessApi(req)) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', { req });
         }
 
         const name = self.getProvider(req.query.provider)?.name;


### PR DESCRIPTION
## Summary
- add request data to `forbidden` errors
- include request info when user is not found in password reset
- extend context for page and piece operations

## Testing
- `npm test` *(fails: MongoDB connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_6845428d4c708327ab18b582a325fd8d