### PR TITLE
Improve logging for apos errors

### DIFF
--- a/modules/@apostrophecms/attachment/index.js
+++ b/modules/@apostrophecms/attachment/index.js
@@ -167,7 +167,8 @@ module.exports = {
               const file = Object.values(req.files || {})[0];
 
               if (!file) {
-                throw self.apos.error('invalid');
+                const fields = Object.keys(req.files || {}).join(', ');
+                throw self.apos.error('invalid', `No file uploaded (fields: ${fields})`);
               }
 
               const attachment = await self.insert(req, file);
@@ -204,13 +205,13 @@ module.exports = {
             const { crop } = req.body;
 
             if (!_id || !crop || typeof crop !== 'object' || Array.isArray(crop)) {
-              throw self.apos.error('invalid');
+              throw self.apos.error('invalid', `Missing or malformed crop data for ${_id}`);
             }
 
             const sanitizedCrop = self.sanitizeCrop(crop);
 
             if (!sanitizedCrop) {
-              throw self.apos.error('invalid');
+              throw self.apos.error('invalid', `Invalid crop coordinates: ${JSON.stringify(crop)}`);
             }
 
             await self.crop(req, _id, sanitizedCrop);

--- a/modules/@apostrophecms/color-field/index.js
+++ b/modules/@apostrophecms/color-field/index.js
@@ -33,7 +33,7 @@ module.exports = {
             const isUndefined = _.isUndefined(destination[field.name]) ||
               !destination[field.name].toString().length;
             if (field.required && isUndefined) {
-              throw self.apos.error('required');
+              throw self.apos.error('required', `Color value required for ${field.name}`);
             }
 
             const test = new TinyColor(destination[field.name]);

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -798,7 +798,7 @@ module.exports = {
         if (options.copyingId) {
           copyOf = await self.findOneForCopying(req, { _id: options.copyingId });
           if (!copyOf) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', `Document to copy not found: ${options.copyingId}`);
           }
           input = {
             ...copyOf,
@@ -865,7 +865,7 @@ module.exports = {
       // and `at` properties.
       async submit(req, draft) {
         if (!self.apos.permission.can(req, 'edit', draft)) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', `Cannot submit ${draft._id}`);
         }
         const submitted = {
           by: req.user && req.user.title,
@@ -887,10 +887,10 @@ module.exports = {
       async dismissSubmission(req, draft) {
         if (!self.apos.permission.can(req, 'publish', draft)) {
           if (!self.apos.permission.can(req, 'edit', draft)) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', `Cannot dismiss ${draft._id}`);
           }
           if (!(draft.submitted && (draft.submitted.byId === req.user._id))) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', 'Only submitter may dismiss');
           }
         }
         // Don't use "return" here, that could leak mongodb details
@@ -1020,7 +1020,7 @@ module.exports = {
       // to achieve this.
       async unpublish(req, doc, options) {
         if (self.options.singleton) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', 'Cannot unpublish singleton');
         }
 
         const DRAFT_SUFFIX = ':draft';
@@ -1175,7 +1175,7 @@ module.exports = {
                   if (!originalTarget) {
                     // Almost impossible (race conditions like someone removing
                     // it while we're in the modal)
-                    throw self.apos.error('notfound');
+                    throw self.apos.error('notfound', `Original target ${lastTargetId} missing`);
                   }
                   const criteria = {
                     path: self.apos.page.getParentPath(originalTarget)
@@ -1317,7 +1317,7 @@ module.exports = {
         });
         if (!previous) {
           // Feature has already been used
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', `No previous publication for ${published._id}`);
         }
         const $set = await self.getRevertDeduplicationSet(req, previous);
         Object.assign(previous, $set);
@@ -1511,7 +1511,7 @@ module.exports = {
 
       async share(req, doc) {
         if (doc._edit !== true) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', `Document not editable for share: ${doc._id}`);
         }
 
         if (!doc._url) {
@@ -1537,7 +1537,7 @@ module.exports = {
 
       async unshare(req, doc) {
         if (doc._edit !== true) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', `Document not editable for unshare: ${doc._id}`);
         }
 
         if (!doc._url) {

--- a/modules/@apostrophecms/doc/index.js
+++ b/modules/@apostrophecms/doc/index.js
@@ -53,7 +53,7 @@ module.exports = {
         _id = self.apos.i18n.inferIdLocaleAndMode(req, _id);
         const doc = await self.find(req, { _id }).permission('edit').toObject();
         if (!doc) {
-          throw self.apos.error('notfound');
+          throw self.apos.error('notfound', `Document not found: ${_id}`);
         }
         return doc;
       }
@@ -64,7 +64,7 @@ module.exports = {
       post: {
         async slugTaken(req) {
           if (!req.user) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', 'User must be logged in for slug check');
           }
           const slug = self.apos.launder.string(req.body.slug);
           const _id = self.apos.launder.id(req.body._id);
@@ -100,7 +100,7 @@ module.exports = {
         // might not be accepted as a query string.
         async editable(req) {
           if (!req.user) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', 'User must be logged in to check editability');
           }
           const ids = self.apos.launder.ids(req.body.ids);
           if (!ids.length) {
@@ -197,7 +197,7 @@ module.exports = {
         testPermissions(req, doc, options) {
           if (!(options.permissions === false)) {
             if (!self.apos.permission.can(req, 'delete', doc)) {
-              throw self.apos.error('forbidden');
+              throw self.apos.error('forbidden', `No permission to delete ${doc._id}`);
             }
           }
         }
@@ -206,7 +206,7 @@ module.exports = {
         testPermissions(req, info) {
           if (info.options.permissions !== false) {
             if (!self.apos.permission.can(req, info.options.autopublishing ? 'edit' : 'publish', info.draft)) {
-              throw self.apos.error('forbidden');
+              throw self.apos.error('forbidden', `Cannot publish ${info.draft._id}`);
             }
           }
         }
@@ -366,7 +366,7 @@ module.exports = {
           const existing = await self.apos.doc.db
             .findOne({ _id: skipReplace ? to : from });
           if (!existing) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', `Document ${skipReplace ? to : from} not found`);
           }
           const replacement = klona(existing);
           if (!skipReplace) {
@@ -904,7 +904,7 @@ module.exports = {
       testInsertPermissions(req, doc, options) {
         if (options.permissions !== false) {
           if (!self.apos.permission.can(req, 'create', doc)) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', `No permission to create ${doc.type}`);
           }
         }
       },
@@ -947,7 +947,7 @@ module.exports = {
 
       async deleteBody(req, doc, options) {
         if ((options.permissions !== false) && (!self.apos.permission.can(req, 'delete', doc))) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', `No permission to delete ${doc._id}`);
         }
         return self.db.removeOne({
           _id: doc._id
@@ -1393,17 +1393,17 @@ module.exports = {
             }
           });
           if (!info) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', `Document not found for locking: ${_id}`);
           }
           if (!info.advisoryLock) {
             // Nobody else has a lock but you couldn't get one —
             // must be permissions
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', `No lock for ${_id}`);
           }
           if (!info.advisoryLock) {
             // Nobody else has a lock but you couldn't get one —
             // must be permissions
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', `No lock for ${_id}`);
           }
           if (info.advisoryLock.username === req.user.username) {
             throw self.apos.error('locked', {

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -420,7 +420,7 @@ module.exports = {
             }
           }
           if (!sanitizedLocale) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', `Invalid locale prefix: ${req.query.locale}`);
           }
           const result = {};
           if (doc && doc._url) {
@@ -468,7 +468,7 @@ module.exports = {
           const originalMode = (ids[0] && ids[0].split(':')[2]) || req.mode;
           const mode = self.apos.launder.string(req.body.mode, originalMode);
           if (!self.isValidLocale(locale)) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', `Invalid locale provided: ${locale}`);
           }
           const found = await self.apos.doc.db.find({
             aposLocale: `${locale}:${mode}`,
@@ -875,10 +875,10 @@ module.exports = {
           throw self.apos.error('forbidden');
         }
         if (!Array.isArray(req.body._ids)) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', `Expected _ids array, got ${typeof req.body._ids}`);
         }
         if (!Array.isArray(req.body.toLocales)) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', `Expected toLocales array, got ${typeof req.body.toLocales}`);
         }
 
         const ids = self.apos.launder.ids(req.body._ids)

--- a/modules/@apostrophecms/image/index.js
+++ b/modules/@apostrophecms/image/index.js
@@ -162,7 +162,7 @@ module.exports = {
     post: {
       async autocrop(req) {
         if (!self.apos.permission.can(req, 'upload-attachment')) {
-          throw self.apos.error('forbidden');
+          throw self.apos.error('forbidden', 'Permission denied to upload attachments');
         }
         const widgetOptions = sanitizeOptions(req.body.widgetOptions);
         if (!widgetOptions.aspectRatio) {

--- a/modules/@apostrophecms/login/index.js
+++ b/modules/@apostrophecms/login/index.js
@@ -197,7 +197,7 @@ module.exports = {
           );
 
           if (!user) {
-            throw self.apos.error('invalid');
+            throw self.apos.error('invalid', 'User not found for requirement');
           }
 
           const requirement = self.requirements[name];
@@ -588,10 +588,10 @@ module.exports = {
         const email = self.apos.launder.string(usernameOrEmail);
 
         if (!email.length) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', 'Email required');
         }
         if (resetToken !== false && !reset.length) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', 'Reset token invalid');
         }
         const adminReq = self.apos.task.getReq();
         const criteriaOr = [

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -372,7 +372,7 @@ module.exports = {
             }
 
             if (!page) {
-              throw self.apos.error('notfound');
+              throw self.apos.error('notfound', `Page not found: ${req.params._id}`);
             }
 
             if (flat) {
@@ -399,7 +399,7 @@ module.exports = {
             }
 
             if (!result) {
-              throw self.apos.error('notfound');
+              throw self.apos.error('notfound', `Home page not found for locale ${req.locale}`);
             }
 
             // Attach `_url` and `_urls` properties to the home page
@@ -445,7 +445,7 @@ module.exports = {
           }
 
           if (!result) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', `Page ${req.params._id} not found`);
           }
           const renderAreas = req.query['render-areas'];
           const inline = renderAreas === 'inline';
@@ -519,7 +519,7 @@ module.exports = {
             .toObject();
 
           if (!targetPage) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', `Target page ${targetId} not found`);
           }
           const manager = self.apos.doc.getManager(self.apos.launder.string(input.type));
           if (!manager) {
@@ -532,7 +532,7 @@ module.exports = {
           } else {
             const parentPage = targetPage._ancestors[targetPage._ancestors.length - 1];
             if (!parentPage) {
-              throw self.apos.error('notfound');
+              throw self.apos.error('notfound', `Parent page missing for ${targetId}`);
             }
             page = self.newChild(parentPage);
           }
@@ -582,10 +582,10 @@ module.exports = {
         return self.withLock(req, async () => {
           const page = await self.findForEditing(req, { _id }).toObject();
           if (!page) {
-            throw self.apos.error('notfound');
+            throw self.apos.error('notfound', `Page not found: ${_id}`);
           }
           if (!page._edit) {
-            throw self.apos.error('forbidden');
+            throw self.apos.error('forbidden', `No edit permission for ${_id}`);
           }
           const input = req.body;
           const manager = self.apos.doc.getManager(

--- a/modules/@apostrophecms/schema/index.js
+++ b/modules/@apostrophecms/schema/index.js
@@ -2206,7 +2206,7 @@ module.exports = {
           !self.fieldTypes[field.type].dynamicChoices ||
           !(field.choices && typeof field.choices === 'string')
         ) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', `Dynamic choices misconfigured for field ${fieldId}`);
         }
         if (field.following) {
           for (const follows of field.following) {

--- a/modules/@apostrophecms/schema/lib/addFieldTypes.js
+++ b/modules/@apostrophecms/schema/lib/addFieldTypes.js
@@ -124,7 +124,7 @@ module.exports = (self) => {
         field.required &&
         (_.isUndefined(data[field.name]) || !data[field.name].toString().length)
       ) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', `Field ${field.name} is required`);
       }
 
       if (field.pattern) {
@@ -436,10 +436,10 @@ module.exports = (self) => {
         field.required &&
         ((data[field.name] == null) || !data[field.name].toString().length)
       ) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', `Field ${field.name} is required`);
       }
       if (data[field.name] && isNaN(parseFloat(data[field.name]))) {
-        throw self.apos.error('invalid');
+        throw self.apos.error('invalid', `Field ${field.name} is not a number`);
       }
       // This makes it possible to have a field that is not required,
       // but min / max defined. This allows the form to be saved and
@@ -499,10 +499,10 @@ module.exports = (self) => {
         field.required &&
         (_.isUndefined(data[field.name]) || !data[field.name].toString().length)
       ) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', `Field ${field.name} is required`);
       }
       if (data[field.name] && isNaN(parseFloat(data[field.name]))) {
-        throw self.apos.error('invalid');
+        throw self.apos.error('invalid', `Field ${field.name} is not a number`);
       }
       if (!data[field.name] && data[field.name] !== 0) {
         destination[field.name] = null;
@@ -551,13 +551,13 @@ module.exports = (self) => {
       destination[field.name] = self.apos.launder.string(data[field.name]);
       if (!data[field.name]) {
         if (field.required) {
-          throw self.apos.error('required');
+          throw self.apos.error('required', `Field ${field.name} is required`);
         }
       } else {
         // regex source: https://emailregex.com/
         const matches = data[field.name].match(/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);
         if (!matches) {
-          throw self.apos.error('invalid');
+          throw self.apos.error('invalid', `Field ${field.name} is not a valid email`);
         }
       }
       destination[field.name] = data[field.name];
@@ -574,7 +574,7 @@ module.exports = (self) => {
         field.required &&
         (data[field.name] == null || !data[field.name].toString().length)
       ) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', `Field ${field.name} is required`);
       }
 
       if (field.pattern) {
@@ -756,10 +756,10 @@ module.exports = (self) => {
         field.required &&
         (_.isUndefined(data[field.name]) || !data[field.name].toString().length)
       ) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', `Field ${field.name} is required`);
       }
       if (data[field.name] && isNaN(parseFloat(data[field.name]))) {
-        throw self.apos.error('invalid');
+        throw self.apos.error('invalid', `Field ${field.name} is not a number`);
       }
       // Allow for ranges to go unset `min` here does not imply requirement,
       // it is the minimum value the range UI will represent
@@ -847,7 +847,7 @@ module.exports = (self) => {
       }
       destination[field.name] = results;
       if (field.required && !results.length) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', `At least one entry required for ${field.name}`);
       }
       if ((field.min !== undefined) && (results.length < field.min)) {
         throw self.apos.error('min');
@@ -1178,7 +1178,7 @@ module.exports = (self) => {
         destination[field.name] = actualDocs;
       }
       if (field.required && (destination[field.name].length === 0)) {
-        throw self.apos.error('required');
+        throw self.apos.error('required', `Field ${field.name} is required`);
       }
       if (field.min && field.min > destination[field.name].length) {
         throw self.apos.error('min', `Minimum ${field.withType} required not reached.`);

--- a/modules/@apostrophecms/util/index.js
+++ b/modules/@apostrophecms/util/index.js
@@ -664,6 +664,23 @@ module.exports = {
       // substitution strings in mind. See the
       // `console.error` documentation.
       error(...args) {
+        if (
+          args.length === 1 &&
+          args[0] instanceof Error &&
+          args[0].aposError &&
+          ['invalid', 'notfound', 'forbidden', 'required'].includes(args[0].name)
+        ) {
+          const err = args[0];
+          const context = err.data && Object.keys(err.data).length
+            ? ` ${JSON.stringify(err.data)}`
+            : '';
+          const message = `${err.name}: ${err.message}${context}`;
+          self.logger.error(...self.convertLegacyLogPayload([ message ]));
+          if (err.stack) {
+            self.logger.error(err.stack);
+          }
+          return;
+        }
         self.logger.error(...self.convertLegacyLogPayload(args));
       },
       // Performance profiling method. At the start of the operation you want


### PR DESCRIPTION
## Summary
- add context to invalid upload and crop errors
- detail locale and localization validation
- improve user and notification checks
- expand doc and page error messages
- include field information in schema validation

## Testing
- `npm test` *(fails: MongoServerSelectionError)*

------
https://chatgpt.com/codex/tasks/task_e_68457b29ebb48327a1170aabe6081a2a